### PR TITLE
wpa_supplicant speed improvements

### DIFF
--- a/wpa_supplicant-2.8/src/common/sae.c
+++ b/wpa_supplicant-2.8/src/common/sae.c
@@ -154,12 +154,15 @@ static struct crypto_bignum * sae_get_rand(struct sae_data *sae)
 	if (order_len > sizeof(val))
 		return NULL;
 
+/* WPA3 brute: Save randomisation initialisation
 	for (;;) {
 		if (iter++ > 100 || random_get_bytes(val, order_len) < 0)
 			return NULL;
 		if (order_len_bits % 8)
 			buf_shift_right(val, order_len, 8 - order_len_bits % 8);
+*/
 		bn = crypto_bignum_init_set(val, order_len);
+/* WPA3 brute: save time checking result
 		if (bn == NULL)
 			return NULL;
 		if (crypto_bignum_is_zero(bn) ||
@@ -172,6 +175,7 @@ static struct crypto_bignum * sae_get_rand(struct sae_data *sae)
 	}
 
 	os_memset(val, 0, order_len);
+*/
 	return bn;
 }
 
@@ -463,7 +467,8 @@ static int sae_derive_pwe_ecc(struct sae_data *sae, const u8 *addr1,
 			      const u8 *addr2, const u8 *password,
 			      size_t password_len, const char *identifier)
 {
-	u8 counter, k = 40;
+	//u8 counter, k = 40; // WPA3 brute: remove constant time loop
+	u8 counter, k = 1;
 	u8 addrs[2 * ETH_ALEN];
 	const u8 *addr[3];
 	size_t len[3];

--- a/wpa_supplicant-2.8/wpa_supplicant/Makefile
+++ b/wpa_supplicant-2.8/wpa_supplicant/Makefile
@@ -275,6 +275,8 @@ CFLAGS += -DCONFIG_SAE
 OBJS += ../src/common/sae.o
 NEED_ECC=y
 NEED_DH_GROUPS=y
+# WPA3 brute: needed for compilation of SAE on some platforms
+NEED_AES_OMAC1=y
 endif
 
 ifdef CONFIG_DPP

--- a/wpa_supplicant-2.8/wpa_supplicant/sme.c
+++ b/wpa_supplicant-2.8/wpa_supplicant/sme.c
@@ -1256,6 +1256,10 @@ void sme_event_auth(struct wpa_supplicant *wpa_s, union wpa_event_data *data)
 		return;
 	}
 
+// WPA3 brute: notify of success/failure earlier
+  if (data->auth.status_code == 1) wpa_msg_ctrl(wpa_s, MSG_INFO, WPA_EVENT_BRUTE_FAILURE);
+  if (data->auth.auth_transaction == 2 && data->auth.status_code == 0) wpa_msg_ctrl(wpa_s, MSG_INFO, WPA_EVENT_BRUTE_SUCCESS);
+
 	wpa_dbg(wpa_s, MSG_DEBUG, "SME: Authentication response: peer=" MACSTR
 		" auth_type=%d auth_transaction=%d status_code=%d",
 		MAC2STR(data->auth.peer), data->auth.auth_type,


### PR DESCRIPTION
This patch will speed up the SAE and notify of success/failure earlier.

SAE tried to prevent side channel attacks by performing the hunting and pecking algorithm in a constant time, lately of 40 rounds. Reducing this to 1 saves time on the brute.

I started playing with other places like reducing randomisation initialisations, there are numerous other places speedups can be gained.

This will also notify of a success or failure sooner than when it would normally hit notify, I think.