### PR TITLE
wacker.py: Add event handling for missing network, fix shebang

### DIFF
--- a/wacker.py
+++ b/wacker.py
@@ -145,6 +145,10 @@ class Wacker(object):
                 self.send_to_server(f'DISABLE_NETWORK 0')
                 logging.info('NETWORK NOT FOUND\n')
                 return Wacker.EXIT
+            elif event == "<3>CTRL-EVENT-SCAN-FAILED":
+                self.send_to_server(f'DISABLE_NETWORK 0')
+                logging.info('SCAN FAILURE')
+                return Wacker.EXIT
             elif event == "<3>CTRL-EVENT-BRUTE-SUCCESS":
                 self.print_stats(count)
                 logging.info('BRUTE ATTEMPT SUCCESS\n')
@@ -228,10 +232,10 @@ def attempt(word, count):
     while True:
         wacker.send_connection_attempt(word)
         result = wacker.listen(count)
-        if result != Wacker.RETRY:
-            return result
-        elif result == Wacker.EXIT:
+        if result == Wacker.EXIT:
             sys.exit(1)
+        elif result != Wacker.RETRY:
+            return result
 
 # Start the cracking
 count = 1

--- a/wacker.py
+++ b/wacker.py
@@ -11,7 +11,6 @@ import subprocess
 import sys
 import time
 
-
 def kill(sig, frame):
     try:
         wacker.kill()
@@ -26,6 +25,7 @@ class Wacker(object):
     RETRY = 0
     SUCCESS = 1
     FAILURE = 2
+    EXIT = 3
 
     def __init__(self, args, start_word):
         self.args = args
@@ -142,7 +142,7 @@ class Wacker(object):
             elif event == "<3>CTRL-EVENT-NETWORK-NOT-FOUND":
                 self.send_to_server(f'DISABLE_NETWORK 0')
                 logging.info('NETWORK NOT FOUND\n')
-                return Wacker.FAILURE
+                return Wacker.EXIT
             elif event == "<3>CTRL-EVENT-BRUTE-SUCCESS":
                 self.print_stats(count)
                 logging.info('BRUTE ATTEMPT SUCCESS\n')
@@ -228,6 +228,8 @@ def attempt(word, count):
         result = wacker.listen(count)
         if result != Wacker.RETRY:
             return result
+        elif result == Wacker.EXIT:
+            sys.exit(1)
 
 # Start the cracking
 count = 1

--- a/wacker.py
+++ b/wacker.py
@@ -11,6 +11,8 @@ import subprocess
 import sys
 import time
 
+assert sys.version_info >= (3,7)
+
 def kill(sig, frame):
     try:
         wacker.kill()

--- a/wacker.py
+++ b/wacker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 
 import argparse
 import logging
@@ -138,6 +138,10 @@ class Wacker(object):
                 self.print_stats(count)
                 self.send_to_server(f'DISABLE_NETWORK 0')
                 logging.info('BRUTE ATTEMPT FAIL\n')
+                return Wacker.FAILURE
+            elif event == "<3>CTRL-EVENT-NETWORK-NOT-FOUND":
+                self.send_to_server(f'DISABLE_NETWORK 0')
+                logging.info('NETWORK NOT FOUND\n')
                 return Wacker.FAILURE
             elif event == "<3>CTRL-EVENT-BRUTE-SUCCESS":
                 self.print_stats(count)


### PR DESCRIPTION
- Small quality of life improvement to prevent the program from "hanging" if the network isn't found.
- All systems I've used have python3 (as a symlink to python3.7, or 3.8, etc). The current way will break on systems with newer versions.